### PR TITLE
Migrate module from ServiceMeshExtension to WasmPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build/
 target/
-extension.wasm
+plugin.wasm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HUB ?= quay.io/isanchez
+HUB ?= quay.io/acidonpe
 IMAGE ?= ossm-example-body-extension
 VERSION ?= 1.0.0
 
@@ -6,18 +6,18 @@ build: wasm
 
 wasm:
 	cargo build --target wasm32-unknown-unknown --release
-	cp target/wasm32-unknown-unknown/release/ossm_example_body_extension.wasm ./extension.wasm
+	cp target/wasm32-unknown-unknown/release/ossm_example_body_extension.wasm ./plugin.wasm
 
 .PHONY: clean
 clean:
-	rm extension.wasm || true
+	rm plugin.wasm || true
 	rm -r build || true
 
 .PHONY: container
 image: clean build
 	mkdir build
 	cp container/manifest.yaml build/
-	cp extension.wasm build/
+	cp plugin.wasm build/
 	cd build && podman build -t ${HUB}/${IMAGE}:${VERSION} . -f ../container/Dockerfile
 
 image.push: image

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HUB ?= quay.io/acidonpe
+HUB ?= quay.io/isanchez
 IMAGE ?= ossm-example-body-extension
 VERSION ?= 1.0.0
 

--- a/service-mesh-extension.yaml
+++ b/service-mesh-extension.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ossm-example-body-extension
 spec:
   pluginConfig: secret
-  url: oci://quay.io/acidonpe/ossm-example-body-extension:1.0.0
+  url: oci://quay.io/isanchez/ossm-example-body-extension:1.0.0
   priority: 100
   phase: STATS
   selector:

--- a/service-mesh-extension.yaml
+++ b/service-mesh-extension.yaml
@@ -1,12 +1,12 @@
-apiVersion: maistra.io/v1alpha1
-kind: ServiceMeshExtension
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
 metadata:
   name: ossm-example-body-extension
 spec:
-  config: secret
-  image: quay.io/isanchez/ossm-example-body-extension:1.0.0
-  phase: PostAuthZ
+  pluginConfig: secret
+  url: oci://quay.io/acidonpe/ossm-example-body-extension:1.0.0
   priority: 100
-  workloadSelector:
-    labels:
+  phase: STATS
+  selector:
+    matchLabels:
       app: httpbin

--- a/service-mesh-extension.yaml
+++ b/service-mesh-extension.yaml
@@ -3,7 +3,8 @@ kind: WasmPlugin
 metadata:
   name: ossm-example-body-extension
 spec:
-  pluginConfig: secret
+  pluginConfig:
+    secret-word: secret
   url: oci://quay.io/isanchez/ossm-example-body-extension:1.0.0
   priority: 100
   phase: STATS


### PR DESCRIPTION
Hi Nacho,

This PR allows the use of WASM plugins from OSSM 2.23.

The procedure used to migrate this plugin was [this](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/ossm-extensions.html#ossm-extensions-migration-overview_ossm-extensions).

Regards!